### PR TITLE
Always use comma-join

### DIFF
--- a/src/irclj/core.clj
+++ b/src/irclj/core.clj
@@ -52,7 +52,7 @@
   (let [[channels opts] (split-with (complement keyword?) channels-and-opts)
         opts (apply hash-map opts)]
     (connection/write-irc-line irc "PART"
-                               (string/join "," channels)
+                               (comma-join channels)
                                (when-let [message (:message opts)]
                                  (connection/end message)))))
 


### PR DESCRIPTION
Hey, I feel kind of silly making such a trivial pull request, but I noticed a part of core.clj that wasn't using comma-join that could be.
