### PR TITLE
Fix test.

### DIFF
--- a/src/irclj/core.clj
+++ b/src/irclj/core.clj
@@ -102,6 +102,11 @@
   (connection/write-irc-line irc "KICK" channel user
                              (when message (connection/end message))))
 
+(defn list
+  "Request list of channels and topics."
+  [irc & channels]
+  (connection/write-irc-line irc "LIST" (clojure.string/join "," channels)))
+
 ;; We fire our raw-log callback for the lines we read from IRC as well.
 (defn- process
   "Prepare and process a line from IRC."

--- a/test/irclj/parser_test.clj
+++ b/test/irclj/parser_test.clj
@@ -3,14 +3,14 @@
         clojure.test))
 
 (deftest parser-test
-  (is (= (parse-message ":amalloy!~amalloy@li231-96.members.linode.com PRIVMSG #4clojure")
+  (is (= (parse ":amalloy!~amalloy@li231-96.members.linode.com PRIVMSG #4clojure")
          {:command "PRIVMSG",
           :params ["#4clojure"],
           :raw ":amalloy!~amalloy@li231-96.members.linode.com PRIVMSG #4clojure",
           :host "li231-96.members.linode.com",
           :user "~amalloy",
           :nick "amalloy"}))
-  (is (= (parse-message ":amalloy!~amalloy@li231-96.members.linode.com PRIVMSG #4clojure :ckirkendall: would you mind using amalloy on irc, rather than alan? it's nice to get notifications from my irc client")
+  (is (= (parse ":amalloy!~amalloy@li231-96.members.linode.com PRIVMSG #4clojure :ckirkendall: would you mind using amalloy on irc, rather than alan? it's nice to get notifications from my irc client")
          {:command "PRIVMSG",
           :params ["#4clojure" "ckirkendall: would you mind using amalloy on irc, rather than alan? it's nice to get notifications from my irc client"],
           :raw ":amalloy!~amalloy@li231-96.members.linode.com PRIVMSG #4clojure :ckirkendall: would you mind using amalloy on irc, rather than alan? it's nice to get notifications from my irc client",


### PR DESCRIPTION
In 40458ce "parse-message" was renamed to "parse", causing test to fail.
Applying rename in test makes test pass again.
