### PR TITLE
Add support for the NOTICE command

### DIFF
--- a/src/irclj/core.clj
+++ b/src/irclj/core.clj
@@ -62,6 +62,12 @@
   (connection/write-irc-line irc "PRIVMSG" target
                              (connection/end (string/join " " s))))
 
+(defn notice
+  "Sends a NOTICE to a user or channel."
+  [irc target & s]
+  (connection/write-irc-line irc "NOTICE" target
+                             (connection/end (string/join " " s))))
+
 (defn reply
   "Reply to a PRIVMSG. Determines user or channel based on original message."
   [irc m & s]


### PR DESCRIPTION
This is primarily used by bots/services etc for a one way interaction
as mentioned here (http://www.irchelp.org/irchelp/ircprimer.html)
eg. it's used by travis-bot for irc messages/notices
