### PR TITLE
default prefixes to []

### DIFF
--- a/src/irclj/core.clj
+++ b/src/irclj/core.clj
@@ -130,6 +130,7 @@
   (let [{:keys [in] :as connection} (connection/create-connection host port ssl?)
         irc (ref {:connection connection
                   :shutdown? false
+                  :prefixes []
                   :pass pass
                   :nick nick
                   :real-name real-name


### PR DESCRIPTION
in case the server doesn't send 005.  I've observed this behavior on the grove.io server.
