### PR TITLE
don't call `throw` without arguments

### DIFF
--- a/src/irclj/core.clj
+++ b/src/irclj/core.clj
@@ -152,7 +152,7 @@
           (catch Exception e
             (deliver (:ready? @irc) false) ;; unblock the promise
             (events/fire irc :on-exception e)
-            (throw))))))
+            (throw e))))))
 
     irc))
 


### PR DESCRIPTION
This was replacing all errors with NullPointerException, which is what happens when `throw` is not passed arguments :X 
